### PR TITLE
Add support for the new Android plugins APIs V2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,3 +57,28 @@ dependencies {
     implementation 'com.google.ar.sceneform:core:1.11.0'
     implementation 'com.google.ar.sceneform:assets:1.11.0'
 }
+
+afterEvaluate {
+    def containsEmbeddingDependencies = false
+    for (def configuration : configurations.all) {
+        for (def dependency : configuration.dependencies) {
+            if (dependency.group == 'io.flutter' &&
+                    dependency.name.startsWith('flutter_embedding') &&
+                    dependency.isTransitive())
+            {
+                containsEmbeddingDependencies = true
+                break
+            }
+        }
+    }
+    if (!containsEmbeddingDependencies) {
+        android {
+            dependencies {
+                def lifecycle_version = "1.1.1"
+                compileOnly "android.arch.lifecycle:runtime:$lifecycle_version"
+                compileOnly "android.arch.lifecycle:common:$lifecycle_version"
+                compileOnly "android.arch.lifecycle:common-java8:$lifecycle_version"
+            }
+        }
+    }
+}

--- a/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArcoreFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArcoreFlutterPlugin.kt
@@ -1,8 +1,12 @@
 package com.difrancescogianmarco.arcore_flutter_plugin
 
-import android.util.Log
+import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.plugins.FlutterPlugin
-import io.flutter.plugin.common.PluginRegistry
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import io.flutter.plugin.common.MethodChannel.Result
+import io.flutter.plugin.common.PluginRegistry.Registrar
 
 class ArcoreFlutterPlugin: FlutterPlugin{
 
@@ -10,13 +14,16 @@ class ArcoreFlutterPlugin: FlutterPlugin{
 
         val TAG = "ArCoreFlutterPlugin"
         @JvmStatic
-        fun registerWith(registrar: PluginRegistry.Registrar) {
+        fun registerWith(registrar: Registrar) {
             registrar
                     .platformViewRegistry()
                     .registerViewFactory("arcore_flutter_plugin", ArCoreViewFactory(registrar.messenger()))
         }
     }
 
-    override fun onAttachedToEngine (p0: FlutterPlugin.FlutterPluginBinding) {}
-    override fun onDetachedFromEngine (p0: FlutterPlugin.FlutterPluginBinding) {}
+    override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        val channel = MethodChannel(flutterPluginBinding.getFlutterEngine().getDartExecutor(), "arcore_flutter_plugin")
+        flutterPluginBinding.getPlatformViewRegistry().registerViewFactory("arcore_flutter_plugin", ArCoreViewFactory(flutterPluginBinding.getBinaryMessenger()))
+    }
+      override fun onDetachedFromEngine (p0: FlutterPlugin.FlutterPluginBinding) {}
 }

--- a/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArcoreFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArcoreFlutterPlugin.kt
@@ -16,4 +16,7 @@ class ArcoreFlutterPlugin: FlutterPlugin{
                     .registerViewFactory("arcore_flutter_plugin", ArCoreViewFactory(registrar.messenger()))
         }
     }
+
+    override fun onAttachedToEngine (p0: FlutterPlugin.FlutterPluginBinding) {}
+    override fun onDetachedFromEngine (p0: FlutterPlugin.FlutterPluginBinding) {}
 }

--- a/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArcoreFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArcoreFlutterPlugin.kt
@@ -4,7 +4,7 @@ import android.util.Log
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.PluginRegistry
 
-class ArcoreFlutterPlugin{
+class ArcoreFlutterPlugin: FlutterPlugin{
 
     companion object {
 

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -32,5 +32,12 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".EmbeddingV1Activity"
+            android:theme="@style/LaunchTheme"
+                android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale"
+            android:hardwareAccelerated="true"
+            android:windowSoftInputMode="adjustResize">
+        </activity>
     </application>
 </manifest>

--- a/example/android/app/src/main/kotlin/com/difrancescogianmarco/EmbeddingV1Activity.kt
+++ b/example/android/app/src/main/kotlin/com/difrancescogianmarco/EmbeddingV1Activity.kt
@@ -4,9 +4,9 @@ import android.os.Bundle;
 import io.flutter.app.FlutterActivity;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
-public class EmbeddingV1Activity extends FlutterActivity {
- @Override
- protected void onCreate(Bundle savedInstanceState) {
+class EmbeddingV1Activity : FlutterActivity() {
+
+ override fun onCreate(savedInstanceState: Bundle?) {
    super.onCreate(savedInstanceState);
    GeneratedPluginRegistrant.registerWith(this);
  }

--- a/example/android/app/src/main/kotlin/com/difrancescogianmarco/EmbeddingV1Activity.kt
+++ b/example/android/app/src/main/kotlin/com/difrancescogianmarco/EmbeddingV1Activity.kt
@@ -1,0 +1,13 @@
+package com.difrancescogianmarco.arcore_flutter_plugin_example
+
+import android.os.Bundle;
+import io.flutter.app.FlutterActivity;
+import io.flutter.plugins.GeneratedPluginRegistrant;
+
+public class EmbeddingV1Activity extends FlutterActivity {
+ @Override
+ protected void onCreate(Bundle savedInstanceState) {
+   super.onCreate(savedInstanceState);
+   GeneratedPluginRegistrant.registerWith(this);
+ }
+}

--- a/example/android/app/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin_example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin_example/MainActivity.kt
@@ -7,8 +7,8 @@ import io.flutter.embedding.engine.FlutterEngine;
 import com.difrancescogianmarco.arcore_flutter_plugin.ArcoreFlutterPlugin;
 
 class MainActivity: FlutterActivity() {
-  @Override
-  public void configureFlutterEngine(FlutterEngine flutterEngine) {
-    flutterEngine.getPlugins().add(new ArcoreFlutterPlugin());
+  
+  override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+    flutterEngine.getPlugins().add(ArcoreFlutterPlugin());
   }
 }

--- a/example/android/app/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin_example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin_example/MainActivity.kt
@@ -2,12 +2,13 @@ package com.difrancescogianmarco.arcore_flutter_plugin_example
 
 import android.os.Bundle
 
-import io.flutter.app.FlutterActivity
-import io.flutter.plugins.GeneratedPluginRegistrant
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
+import com.difrancescogianmarco.arcore_flutter_plugin.ArcoreFlutterPlugin;
 
 class MainActivity: FlutterActivity() {
-  override fun onCreate(savedInstanceState: Bundle?) {
-    super.onCreate(savedInstanceState)
-    GeneratedPluginRegistrant.registerWith(this)
+  @Override
+  public void configureFlutterEngine(FlutterEngine flutterEngine) {
+    flutterEngine.getPlugins().add(new ArcoreFlutterPlugin());
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: arcore_flutter_plugin
 description: Flutter plugin for ARCore SDK, Android platform to build new augmented reality experiences
-version: 0.0.4
+version: 0.0.4+1
 author: Gian Marco Di Francesco <difrancescogianmarco@gmail.com>
 homepage: https://github.com/giandifra/arcore_flutter_plugin
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
   flutter:
@@ -29,7 +29,6 @@ flutter:
   plugin:
     androidPackage: com.difrancescogianmarco.arcore_flutter_plugin
     pluginClass: ArcoreFlutterPlugin
-
   # To add assets to your plugin package, add an assets section, like this:
   # assets:
   #  - images/a_dot_burr.jpeg
@@ -40,7 +39,6 @@ flutter:
   #
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware.
-
   # To add custom fonts to your plugin package, add a fonts section here,
   # in this "flutter" section. Each entry in this list should have a
   # "family" key with the font family name, and a "fonts" key with a


### PR DESCRIPTION
Added support for the new Android plugins APIs V2 as described here:
https://flutter.dev/docs/development/packages-and-plugins/plugin-api-migration#uiactivity-plugin
this should fix #22 , and anyone trying to add this plugin to a project created with flutter > 1.9