### PR TITLE
Initialize an AugmentedImageDatabase only with valid images

### DIFF
--- a/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArCoreAugmentedImagesView.kt
+++ b/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArCoreAugmentedImagesView.kt
@@ -306,7 +306,7 @@ class ArCoreAugmentedImagesView(activity: Activity, context: Context, messenger:
                 augmentedImageDatabase.addImage(key, augmentedImageBitmap)
             } catch (ex: Exception) {
                 Log.i(TAG, "Image with the title $key cannot be added to the database. " +
-                        "The exeption was thrown: " + ex?.toString())
+                        "The exception was thrown: " + ex?.toString())
             }
         }
         config.augmentedImageDatabase = augmentedImageDatabase


### PR DESCRIPTION
_ARCore puts some requirements (https://developers.google.com/ar/develop/java/augmented-images#tips_for_selecting_reference_images) to the images to be able to scan them. In a case, if at least one image does not fulfill the requirements we are not able to build the database, so it is null. The idea is to detect if the image is valid and pass it to the database otherwise skip the image and provide some extra info about the cause of the exception._

**Updates**

1. Improved implementation of the addMultipleImagesToAugmentedImageDatabase method.
2. Prints a log to the console in the case of an invalid image, e.g.:  _"Image with the title some_title.png cannot be added to the database. The exception was thrown: com.google.ar.core.exceptions.ImageInsufficientQualityException"._

P.S. A great tool to check image quality for the ARCore: https://developers.google.com/ar/develop/c/augmented-images/arcoreimg