### PR TITLE
ArCoreReferenceNode objectUrl now using .glb or .gltf2 depending on file extension of URL

### DIFF
--- a/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/RenderableCustomFactory.kt
+++ b/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/RenderableCustomFactory.kt
@@ -48,11 +48,17 @@ class RenderableCustomFactory {
                 } else if (url != null) {
                     val modelRenderableBuilder = ModelRenderable.builder()
                     val renderableSourceBuilder = RenderableSource.builder()
-
-                    renderableSourceBuilder
+                    if(url.endsWith(".glb")){
+                        renderableSourceBuilder
+                            .setSource(context, Uri.parse(url), RenderableSource.SourceType.GLB)
+                            .setScale(0.5f)
+                            .setRecenterMode(RenderableSource.RecenterMode.ROOT)
+                    } else {
+                        renderableSourceBuilder
                             .setSource(context, Uri.parse(url), RenderableSource.SourceType.GLTF2)
                             .setScale(0.5f)
                             .setRecenterMode(RenderableSource.RecenterMode.ROOT)
+                    }
 
                     modelRenderableBuilder
                             .setSource(context, renderableSourceBuilder.build())


### PR DESCRIPTION
Uses GLB extension if the URL is ending with .glb, else it falls back to GLTF2.

GLB can be used to use a local file, for example:
1. During the first time of your Flutter app, download a remote GLB to a cached directory
2. Check if the the cached glb file is on the storage, else download again 
2. The "objectUrl" property of ArCoreReferenceNode is set to "file://path_where_app_saved_the_glb_file"
3. App now uses a local glb file

