### PR TITLE
Added new parameter to enable/disable the white dots on surface

### DIFF
--- a/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArCoreView.kt
+++ b/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArCoreView.kt
@@ -315,6 +315,13 @@ class ArCoreView(val activity: Activity, context: Context, messenger: BinaryMess
             // detected.
             arSceneView?.scene?.addOnUpdateListener(sceneUpdateListener)
         }
+
+        val enablePlaneRenderer: Boolean? = call.argument("enablePlaneRenderer")
+        if (enablePlaneRenderer != null && !enablePlaneRenderer) {
+            Log.i(TAG, " The plane renderer (enablePlaneRenderer) is set to " + enablePlaneRenderer.toString())
+            arSceneView!!.planeRenderer.isVisible = false
+        }
+        
         result.success(null)
     }
 
@@ -482,7 +489,7 @@ class ArCoreView(val activity: Activity, context: Context, messenger: BinaryMess
         }
 
         if (arSceneView?.session != null) {
-//            arSceneView!!.planeRenderer.isVisible = false
+            //arSceneView!!.planeRenderer.isVisible = false
             Log.i(TAG, "Searching for surfaces")
         }
     }

--- a/lib/src/arcore_controller.dart
+++ b/lib/src/arcore_controller.dart
@@ -35,6 +35,7 @@ class ArCoreController {
   ArCoreController({
     int id,
     this.enableTapRecognizer,
+    this.enablePlaneRenderer,
     this.enableUpdateListener,
 //    @required this.onUnsupported,
   }) {
@@ -45,6 +46,7 @@ class ArCoreController {
 
   final bool enableUpdateListener;
   final bool enableTapRecognizer;
+  final bool enablePlaneRenderer;
   MethodChannel _channel;
   StringResultHandler onError;
   StringResultHandler onNodeTap;
@@ -59,6 +61,7 @@ class ArCoreController {
     try {
       await _channel.invokeMethod<void>('init', {
         'enableTapRecognizer': enableTapRecognizer,
+        'enablePlaneRenderer': enablePlaneRenderer,
         'enableUpdateListener': enableUpdateListener,
       });
     } on PlatformException catch (ex) {

--- a/lib/src/arcore_view.dart
+++ b/lib/src/arcore_view.dart
@@ -13,6 +13,7 @@ class ArCoreView extends StatefulWidget {
 //  final UnsupportedHandler onArCoreUnsupported;
 
   final bool enableTapRecognizer;
+  final bool enablePlaneRenderer;
   final bool enableUpdateListener;
   final ArCoreViewType type;
 
@@ -21,6 +22,7 @@ class ArCoreView extends StatefulWidget {
     @required this.onArCoreViewCreated,
 //    @required this.onArCoreUnsupported,
     this.enableTapRecognizer = false,
+    this.enablePlaneRenderer = true,
     this.enableUpdateListener = false,
     this.type = ArCoreViewType.STANDARDVIEW,
   }) : super(key: key);
@@ -58,11 +60,12 @@ class _ArCoreViewState extends State<ArCoreView> with WidgetsBindingObserver {
       return;
     }
     widget.onArCoreViewCreated(ArCoreController(
-      id: id,
-      enableTapRecognizer: widget.enableTapRecognizer,
-      enableUpdateListener: widget.enableUpdateListener,
+        id: id,
+        enableTapRecognizer: widget.enableTapRecognizer,
+        enableUpdateListener: widget.enableUpdateListener,
+        enablePlaneRenderer: widget.enablePlaneRenderer
 //      onUnsupported: widget.onArCoreUnsupported,
-    ));
+        ));
   }
 
   @override


### PR DESCRIPTION
Added the ability to disable or enable the plane renderer (white dots) when it detects surfaces

The ArCoreView() now has a new property named "enablePlaneRenderer", by default its turned on which means you'll see the white dots.