### PR TITLE
Object is not abstract and does not implement abstract member public abstract fun onactivitycreated

### DIFF
--- a/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArCoreView.kt
+++ b/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArCoreView.kt
@@ -243,7 +243,7 @@ class ArCoreView(val activity: Activity, context: Context, messenger: BinaryMess
 
     private fun setupLifeCycle(context: Context) {
         activityLifecycleCallbacks = object : Application.ActivityLifecycleCallbacks {
-            override fun onActivityCreated(activity: Activity?, savedInstanceState: Bundle?) {
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
                 debugLog("onActivityCreated")
 //                maybeEnableArButton()
             }


### PR DESCRIPTION
object is not abstract and does not implement abstract member public abstract fun onactivitycreated(@nonnull p0: activity, @nullable p1: bundle?): unit defined in android.app.application.activitylifecyclecallbacks

https://github.com/giandifra/arcore_flutter_plugin/issues/149