### PR TITLE
Replace abandoned Google Sceneform with maintained fork

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.difrancescogianmarco.arcore_flutter_plugin'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.30'
     repositories {
         google()
         jcenter()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -54,10 +54,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.google.ar:core:1.13.0'
-    implementation 'com.google.ar.sceneform:core:1.13.0'
-    implementation 'com.google.ar.sceneform:assets:1.13.0'
-    implementation 'com.google.ar.sceneform.ux:sceneform-ux:1.13.0'
+    implementation "com.gorisse.thomas.sceneform:sceneform:1.20.4"
     implementation 'androidx.core:core-ktx:1.3.0-alpha01'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.6'
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 15 12:06:53 AWST 2020
+#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip

--- a/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArCoreAugmentedImagesView.kt
+++ b/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArCoreAugmentedImagesView.kt
@@ -13,8 +13,6 @@ import com.google.ar.core.*
 import com.google.ar.core.exceptions.*
 import com.google.ar.sceneform.AnchorNode
 import com.google.ar.sceneform.Scene
-import com.gorisse.thomas.sceneform.light.LightEstimationConfig
-import com.gorisse.thomas.sceneform.lightEstimationConfig
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -238,15 +236,7 @@ class ArCoreAugmentedImagesView(activity: Activity, context: Context, messenger:
                     val config = Config(session)
                     config.focusMode = Config.FocusMode.AUTO
                     config.updateMode = Config.UpdateMode.LATEST_CAMERA_IMAGE
-                    val lightEstimationConfig: LightEstimationConfig? = arSceneView?.lightEstimationConfig
-                    if (lightEstimationConfig != null) {
-                        config.lightEstimationMode = lightEstimationConfig.mode
-                    }
-                    if (session.cameraConfig.facingDirection == CameraConfig.FacingDirection.FRONT
-                        && config.lightEstimationMode == Config.LightEstimationMode.ENVIRONMENTAL_HDR
-                    ) {
-                        config.lightEstimationMode = Config.LightEstimationMode.DISABLED
-                    }
+                    ArCoreUtils.updateLightEstimationModeFromView(session, config, arSceneView)
                     session.configure(config)
                     arSceneView?.setSession(session)
                 }
@@ -273,6 +263,7 @@ class ArCoreAugmentedImagesView(activity: Activity, context: Context, messenger:
             val config = Config(session)
             config.focusMode = Config.FocusMode.AUTO
             config.updateMode = Config.UpdateMode.LATEST_CAMERA_IMAGE
+            ArCoreUtils.updateLightEstimationModeFromView(session, config, arSceneView)
             bytes?.let {
                 if (useSingleImage) {
                     if (!addImageToAugmentedImageDatabase(config, bytes)) {
@@ -298,6 +289,7 @@ class ArCoreAugmentedImagesView(activity: Activity, context: Context, messenger:
             val config = Config(session)
             config.focusMode = Config.FocusMode.AUTO
             config.updateMode = Config.UpdateMode.LATEST_CAMERA_IMAGE
+            ArCoreUtils.updateLightEstimationModeFromView(session, config, arSceneView)
             bytesMap?.let {
                 addMultipleImagesToAugmentedImageDatabase(config, bytesMap, session)
             }

--- a/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArCoreFaceView.kt
+++ b/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArCoreFaceView.kt
@@ -126,7 +126,7 @@ class ArCoreFaceView(activity:Activity,context: Context, messenger: BinaryMessen
         if (enableAugmentedFaces != null && enableAugmentedFaces) {
             // This is important to make sure that the camera stream renders first so that
             // the face mesh occlusion works correctly.
-            arSceneView?.cameraStreamRenderPriority = Renderable.RENDER_PRIORITY_FIRST
+            arSceneView?.setCameraStreamRenderPriority(Renderable.RENDER_PRIORITY_FIRST)
             arSceneView?.scene?.addOnUpdateListener(faceSceneUpdateListener)
         }
 
@@ -157,7 +157,7 @@ class ArCoreFaceView(activity:Activity,context: Context, messenger: BinaryMessen
                     config.augmentedFaceMode = Config.AugmentedFaceMode.MESH3D
                     config.updateMode = Config.UpdateMode.LATEST_CAMERA_IMAGE
                     session.configure(config)
-                    arSceneView?.setupSession(session)
+                    arSceneView?.setSession(session)
                 }
             } catch (e: UnavailableException) {
                 ArCoreUtils.handleSessionException(activity, e)

--- a/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArCoreFaceView.kt
+++ b/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArCoreFaceView.kt
@@ -156,6 +156,7 @@ class ArCoreFaceView(activity:Activity,context: Context, messenger: BinaryMessen
                     val config = Config(session)
                     config.augmentedFaceMode = Config.AugmentedFaceMode.MESH3D
                     config.updateMode = Config.UpdateMode.LATEST_CAMERA_IMAGE
+                    ArCoreUtils.updateLightEstimationModeFromView(session, config, arSceneView)
                     session.configure(config)
                     arSceneView?.setSession(session)
                 }

--- a/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArCoreView.kt
+++ b/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArCoreView.kt
@@ -16,6 +16,7 @@ import com.difrancescogianmarco.arcore_flutter_plugin.flutter_models.FlutterArCo
 import com.difrancescogianmarco.arcore_flutter_plugin.flutter_models.FlutterArCorePose
 import com.difrancescogianmarco.arcore_flutter_plugin.models.RotatingNode
 import com.difrancescogianmarco.arcore_flutter_plugin.utils.ArCoreUtils
+import com.difrancescogianmarco.arcore_flutter_plugin.utils.DecodableUtils.Companion.parseVector3
 import com.google.ar.core.*
 import com.google.ar.core.exceptions.CameraNotAvailableException
 import com.google.ar.core.exceptions.UnavailableException
@@ -35,6 +36,8 @@ import android.os.Environment
 import android.view.PixelCopy
 import android.os.HandlerThread
 import android.content.ContextWrapper
+import com.gorisse.thomas.sceneform.light.LightEstimationConfig
+import com.gorisse.thomas.sceneform.lightEstimationConfig
 import java.io.FileOutputStream
 import java.io.File
 import java.io.IOException
@@ -547,8 +550,17 @@ class ArCoreView(val activity: Activity, context: Context, messenger: BinaryMess
                     }
                     config.updateMode = Config.UpdateMode.LATEST_CAMERA_IMAGE
                     config.focusMode = Config.FocusMode.AUTO;
+                    val lightEstimationConfig: LightEstimationConfig? = arSceneView?.lightEstimationConfig
+                    if (lightEstimationConfig != null) {
+                        config.lightEstimationMode = lightEstimationConfig.mode
+                    }
+                    if (session.cameraConfig.facingDirection == CameraConfig.FacingDirection.FRONT
+                        && config.lightEstimationMode == Config.LightEstimationMode.ENVIRONMENTAL_HDR
+                    ) {
+                        config.lightEstimationMode = Config.LightEstimationMode.DISABLED
+                    }
                     session.configure(config)
-                    arSceneView?.setupSession(session)
+                    arSceneView?.setSession(session)
                 }
             } catch (ex: UnavailableUserDeclinedInstallationException) {
                 // Display an appropriate message to the user zand return gracefully.

--- a/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArCoreView.kt
+++ b/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArCoreView.kt
@@ -36,8 +36,6 @@ import android.os.Environment
 import android.view.PixelCopy
 import android.os.HandlerThread
 import android.content.ContextWrapper
-import com.gorisse.thomas.sceneform.light.LightEstimationConfig
-import com.gorisse.thomas.sceneform.lightEstimationConfig
 import java.io.FileOutputStream
 import java.io.File
 import java.io.IOException
@@ -549,16 +547,8 @@ class ArCoreView(val activity: Activity, context: Context, messenger: BinaryMess
                         config.augmentedFaceMode = Config.AugmentedFaceMode.MESH3D
                     }
                     config.updateMode = Config.UpdateMode.LATEST_CAMERA_IMAGE
-                    config.focusMode = Config.FocusMode.AUTO;
-                    val lightEstimationConfig: LightEstimationConfig? = arSceneView?.lightEstimationConfig
-                    if (lightEstimationConfig != null) {
-                        config.lightEstimationMode = lightEstimationConfig.mode
-                    }
-                    if (session.cameraConfig.facingDirection == CameraConfig.FacingDirection.FRONT
-                        && config.lightEstimationMode == Config.LightEstimationMode.ENVIRONMENTAL_HDR
-                    ) {
-                        config.lightEstimationMode = Config.LightEstimationMode.DISABLED
-                    }
+                    config.focusMode = Config.FocusMode.AUTO
+                    ArCoreUtils.updateLightEstimationModeFromView(session, config, arSceneView)
                     session.configure(config)
                     arSceneView?.setSession(session)
                 }

--- a/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/MaterialCustomFactory.kt
+++ b/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/MaterialCustomFactory.kt
@@ -7,7 +7,6 @@ import com.difrancescogianmarco.arcore_flutter_plugin.flutter_models.FlutterArCo
 import com.difrancescogianmarco.arcore_flutter_plugin.flutter_models.FlutterArCoreNode
 import com.google.ar.sceneform.rendering.Color
 import com.google.ar.sceneform.rendering.Material
-import com.google.ar.sceneform.rendering.R
 import com.google.ar.sceneform.rendering.Texture
 import java.util.concurrent.CompletableFuture
 

--- a/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/RenderableCustomFactory.kt
+++ b/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/RenderableCustomFactory.kt
@@ -9,7 +9,6 @@ import android.util.Log
 import android.widget.ImageView
 import android.widget.Toast
 import com.difrancescogianmarco.arcore_flutter_plugin.flutter_models.FlutterArCoreNode
-import com.google.ar.sceneform.assets.RenderableSource
 import com.google.ar.sceneform.rendering.Material
 import com.google.ar.sceneform.rendering.ModelRenderable
 import com.google.ar.sceneform.rendering.Renderable
@@ -38,6 +37,7 @@ class RenderableCustomFactory {
                 if (localObject != null) {
                     val builder = ModelRenderable.builder()
                     builder.setSource(context, Uri.parse(localObject))
+                        .setIsFilamentGltf(true)
                     builder.build().thenAccept { renderable ->
                         handler(renderable, null)
                     }.exceptionally { throwable ->
@@ -47,21 +47,10 @@ class RenderableCustomFactory {
                     }
                 } else if (url != null) {
                     val modelRenderableBuilder = ModelRenderable.builder()
-                    val renderableSourceBuilder = RenderableSource.builder()
-                    if(url.endsWith(".glb")){
-                        renderableSourceBuilder
-                            .setSource(context, Uri.parse(url), RenderableSource.SourceType.GLB)
-                            .setScale(0.5f)
-                            .setRecenterMode(RenderableSource.RecenterMode.ROOT)
-                    } else {
-                        renderableSourceBuilder
-                            .setSource(context, Uri.parse(url), RenderableSource.SourceType.GLTF2)
-                            .setScale(0.5f)
-                            .setRecenterMode(RenderableSource.RecenterMode.ROOT)
-                    }
 
                     modelRenderableBuilder
-                            .setSource(context, renderableSourceBuilder.build())
+                            .setSource(context, Uri.parse(url))
+                            .setIsFilamentGltf(true)
                             .setRegistryId(url)
                             .build()
                             .thenAccept { renderable ->

--- a/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/utils/ArCoreUtils.kt
+++ b/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/utils/ArCoreUtils.kt
@@ -8,21 +8,22 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
+import android.os.Build.VERSION_CODES
 import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
 import android.util.Log
 import android.view.Gravity
-import androidx.core.app.ActivityCompat
 import android.widget.Toast
 import androidx.annotation.Nullable
+import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import com.google.ar.core.exceptions.*
-import java.util.*
-import androidx.core.content.ContextCompat.getSystemService
-import android.os.Build.VERSION_CODES
 import com.google.ar.core.*
-import com.google.ar.core.CameraConfig
+import com.google.ar.core.exceptions.*
+import com.google.ar.sceneform.ArSceneView
+import com.gorisse.thomas.sceneform.light.LightEstimationConfig
+import com.gorisse.thomas.sceneform.lightEstimationConfig
+import java.util.*
 
 
 class ArCoreUtils {
@@ -90,6 +91,22 @@ class ArCoreUtils {
 
             }
             return session
+        }
+
+        fun updateLightEstimationModeFromView(
+            session: Session,
+            config: Config,
+            arSceneView: ArSceneView?
+        ) {
+            val lightEstimationConfig: LightEstimationConfig? = arSceneView?.lightEstimationConfig
+            if (lightEstimationConfig != null) {
+                config.lightEstimationMode = lightEstimationConfig.mode
+            }
+            if (session.cameraConfig.facingDirection == CameraConfig.FacingDirection.FRONT
+                && config.lightEstimationMode == Config.LightEstimationMode.ENVIRONMENTAL_HDR
+            ) {
+                config.lightEstimationMode = Config.LightEstimationMode.DISABLED
+            }
         }
 
         /** Check to see we have the necessary permissions for this app, and ask for them if we don't.  */

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.30'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.ar.sceneform:plugin:1.13.0'
     }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 22 17:38:23 CEST 2020
+#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0-null-safety.0"
+    version: "0.1.0-null-safety.3"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -113,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
@@ -148,7 +148,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
This is the implementation for the change: https://github.com/giandifra/arcore_flutter_plugin/issues/166
Updating Gradle and Gradle plugin is not strictly related, but without that I had problems building the problem with new Android Studio.
The change was made on the top of the `null-safety` branch, because it's much newer than `master` and this is the version that I use in my project.

Warning: currently it depends on the Scenform version which depends on a bugged Filament version, so this should not be merged, until https://github.com/SceneView/sceneform-android/issues/301 is fixed and new Sceneform is released.