### PR TITLE
Fix nullable bug

### DIFF
--- a/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArcoreFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArcoreFlutterPlugin.kt
@@ -29,7 +29,7 @@ class ArcoreFlutterPlugin : FlutterPlugin, ActivityAware {
         fun registerWith(registrar: Registrar) {
             registrar
                     .platformViewRegistry()
-                    .registerViewFactory(CHANNEL_NAME, ArCoreViewFactory(registrar.activity(), registrar.messenger()))
+                    .registerViewFactory(CHANNEL_NAME, ArCoreViewFactory(registrar.activity() ?: return, registrar.messenger()))
         }
     }
 


### PR DESCRIPTION
There is a bug with null safety like this:
```
/Users/bakatsuyuki/flutter/.pub-cache/hosted/pub.dartlang.org/arcore_flutter_plugin-0.1.0-null-safety.3/android/src/main/kotlin/com/difrancescogianmarco/arcore_flutter_plugin/ArcoreFlutterPlugin.kt: (32, 74): Type mismatch: inferred type is Activity? but Activity was expected

FAILURE: Build failed with an exception.
```

So I fixed it to return if the activity is null.
