### PR TITLE
Fixed the "Namespace not specified #243" issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "com.difrancescogianmarco.arcore_flutter_plugin"
     compileSdk 34
 
     sourceSets {


### PR DESCRIPTION
This commit fixes the [Namespace not specified #243](https://github.com/giandifra/arcore_flutter_plugin/issues/243) issue.