### PR TITLE
Fixed build crashes due to name space error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.difrancesco.arcore_flutter_plugin'
+
     compileSdk 34
 
     sourceSets {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.difrancescogianmarco.arcore_flutter_plugin">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.CAMERA" />
 


### PR DESCRIPTION
I simply removed the package name from the androidManifest.xml to the build.gradle since that was causing the namespace crashes when i would import the package in my flutter project